### PR TITLE
Migrate requirements.txt to a Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+appdirs = "==1.4.3"
+numpy = "==1.12.1"
+pandas = "==0.20.1"
+pyparsing = "==2.2.0"
+python-dateutil = "==2.6.0"
+pytz = "==2017.2"
+six = "==1.10.0"
+GDAL = "==2.1.0"
+
+[requires]
+python_version = "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-appdirs==1.4.3
-GDAL==2.1.0
-numpy==1.12.1
-packaging==16.8
-pandas==0.20.1
-pyparsing==2.2.0
-python-dateutil==2.6.0
-pytz==2017.2
-six==1.10.0


### PR DESCRIPTION
Pipenv is the most-recommended tool for managing Python dependencies and libraries for projects, and this repository is currently using plain old `pip`.

This PR updates the repository to use Pipenv, and swaps the `requirements.txt` file for a `Pipfile`