### PR TITLE
Fix json errors

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -53,6 +53,7 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+	},
         "backcall": {
             "hashes": [
                 "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
@@ -424,6 +425,7 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+	},
         "sqlparse": {
             "hashes": [
                 "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",


### PR DESCRIPTION
## Description

`pipenv install --dev` would raise a JSONDecodeError, and I identified it as a formatting error in Pipfile.lock.  I have no idea how this error arose, but the fix is simple enough.

## Proposed Changes

Add "}" characters that were missing from Pipfile.lock in two places.

## Testing
To test this pull request, run `pipenv install --dev` before and after change, observe the disappearance of error.